### PR TITLE
Change commit message to ask for a single line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for igitt
 
+## 0.2.2.0 -- 2025-07-08
+
+* Commit message input asks for a single-line input instead of multiline
+
 ## 0.2.1.0  -- 2025-07-03
 
 * Add --version argument.

--- a/igitt.cabal
+++ b/igitt.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                igitt
-version:             0.2.1.0
+version:             0.2.2.0
 synopsis:            Git wrapper to work with numbered branches
 homepage:            https://github.com/ners/igitt/blob/master/README.md
 license:             Apache-2.0
@@ -59,13 +59,10 @@ executable igitt
         ansi-terminal,
         base >= 4.16 && < 5,
         extra,
-        lens,
         monad-logger,
         optparse-applicative,
-        prettyprinter,
         process,
         regex-tdfa,
-        terminal,
         terminal-widgets,
         text,
         text-rope-zipper,


### PR DESCRIPTION
Currently, commitMsgInput is a custom multi-line input. However in virtually all cases, it ends up being used as a single-line input but requires extra knowledge on how to press the enter key (holding Alt).

Now, it's actually a single-line input.